### PR TITLE
Enable lockFileMaintenance in Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -94,5 +94,8 @@
     "labels": [
       "security"
     ]
+  },
+  "lockFileMaintenance": {
+    "enabled": true
   }
 }


### PR DESCRIPTION
This ensures Renovate periodically updates lockfile-only dependencies (transitive deps and those without version pins) that would otherwise never get updated.